### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/michaelcantu/046bc579-329d-430e-8b14-ea82a28c64ab/15fd5090-5031-4b2c-afe0-156e93b78f51/_apis/work/boardbadge/96a4f491-c0b7-4a5c-a200-b2ee359c8f63)](https://dev.azure.com/michaelcantu/046bc579-329d-430e-8b14-ea82a28c64ab/_boards/board/t/15fd5090-5031-4b2c-afe0-156e93b78f51/Microsoft.RequirementCategory)
 Calculator.js: a node.js Demonstration Project
 ==============================================
 An example node.js project, including tests with mocha, that behaves like


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#611](https://dev.azure.com/michaelcantu/046bc579-329d-430e-8b14-ea82a28c64ab/_workitems/edit/611). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.